### PR TITLE
Update Python3.7 -> Python3.12 for authproviderAuthHandlerLambda & updateClamAVDefinitionsLambda

### DIFF
--- a/anti-virus-scan-template.yaml
+++ b/anti-virus-scan-template.yaml
@@ -173,7 +173,7 @@ Resources:
           SecretsManagerRegion:
             Ref: AWS::Region
       Handler: index.lambda_handler
-      Runtime: python3.7
+      Runtime: python3.12
     DependsOn:
       - authproviderAuthLambdaExecutionRole
     Metadata:
@@ -605,7 +605,7 @@ Resources:
               - workflowScanFileHandler
               - Arn
       Handler: index.lambda_handler
-      Runtime: python3.7
+      Runtime: python3.12
     DependsOn:
       - updateLambdaIAMRole
     Metadata:

--- a/virusscan/constructs/auth/lib/auth.py
+++ b/virusscan/constructs/auth/lib/auth.py
@@ -60,7 +60,7 @@ class Auth(Construct):
         #
         self._auth_lambda = _lambda.Function(
             self, 'AuthHandler',
-            runtime=_lambda.Runtime.PYTHON_3_7,
+            runtime=_lambda.Runtime.PYTHON_3_12,
             code=_lambda.Code.from_asset('constructs/auth/lib/src'),
             handler='smauthentication.lambda_handler',
             environment={

--- a/virusscan/constructs/build/lib/build.py
+++ b/virusscan/constructs/build/lib/build.py
@@ -79,7 +79,7 @@ class Build(Construct):
 
         func = _lambda.Function(
             self, 'updateAVdefinitions',
-            runtime=_lambda.Runtime.PYTHON_3_7,
+            runtime=_lambda.Runtime.PYTHON_3_12,
             code=_lambda.Code.from_asset('constructs/build/lib/src'),
             handler='updatefunc.lambda_handler',
             environment={


### PR DESCRIPTION
*Issue:* Python3.7 was deprecated from AWS Lambda on Dec 4, 2023, and it's block function creation date was Jan 9, 2024. This means when someone tries to deploy this solution, the CloudFormation stack will fail due to Python3.7 no longer being supported by AWS Lambda. 

*Description of changes:* Updated required files to use Python3.12 instead of Python3.7


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
